### PR TITLE
Require 'resolv' from the Ruby standard library

### DIFF
--- a/lib/only_google_apis.rb
+++ b/lib/only_google_apis.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+
+require "resolv"
 require "only_google_apis/version"
 
 module OnlyGoogleApis


### PR DESCRIPTION
In the context of Ruby on Rails, it's not necessary to require 'resolv',
but this gem is not dependent on rails (and it should not be)